### PR TITLE
feat: Refactor TCP server configuration and logging setups

### DIFF
--- a/examples/dummy_handler.go
+++ b/examples/dummy_handler.go
@@ -9,15 +9,15 @@ import (
 )
 
 type DefaultHandler struct {
-	log *zap.SugaredLogger
+	log *zap.Logger
 }
 
-func NewDefaultHandler(log *zap.SugaredLogger) *DefaultHandler {
+func NewDefaultHandler(log *zap.Logger) *DefaultHandler {
 	return &DefaultHandler{log: log}
 }
 
 func (h *DefaultHandler) Handle(ctx context.Context, conn net.Conn) {
-	traceLog := h.log.With("traceId", ctx.Value(0))
+	traceLog := h.log.With(zap.Any("traceId", ctx.Value(0)))
 	traceLog.Info("default_handler: start handling packages")
 	time.Sleep(time.Second * 3)
 	traceLog.Info("default_handler: finish handling packages")

--- a/examples/main.go
+++ b/examples/main.go
@@ -5,18 +5,24 @@ import (
 
 	"github.com/squaredcow/yats/pkg/config"
 	"github.com/squaredcow/yats/pkg/tcpserver"
+	"go.uber.org/zap"
 )
 
 func main() {
 
-	logger := config.NewLogger()
+	logger, _ := zap.NewDevelopment()
+
+	// encoderConfig := ecszap.NewDefaultEncoderConfig()
+	// core := ecszap.NewCore(encoderConfig, os.Stdout, zap.InfoLevel)
+	// logger := config.NewLogger(core)
+
 	defer config.CloseLogger(logger)
 
 	cfg := config.TcpServerConfigs{
 		Type: "tcp",
 		Host: "localhost",
 		Port: "3000",
-		Pool: config.TCPServerPoolConfigs{
+		ConnPool: config.TcpConnPoolConfigs{
 			MaxSize:            3,
 			WaitForConnTimeout: 5000,
 			NoOpCycle:          3000,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/squaredcow/yats
 
-go 1.22
+go 1.21
 
 require (
 	github.com/google/uuid v1.6.0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,15 +1,19 @@
 package config
 
-// TcpServerConfigs TCP Server configurations
+// TcpServerConfigs represents the configuration parameters necessary
+// for establishing a TCP server connection.
+// These configurations are https://github.com/knadh/koanf compatible.
 type TcpServerConfigs struct {
-	Type string               `koanf:"type"`
-	Host string               `koanf:"host"`
-	Port string               `koanf:"port"`
-	Pool TCPServerPoolConfigs `koanf:"conn-pool"`
+	Type     string             `koanf:"type"`
+	Host     string             `koanf:"host"`
+	Port     string             `koanf:"port"`
+	ConnPool TcpConnPoolConfigs `koanf:"conn-pool"`
 }
 
-// TCPServerPoolConfigs TCP Server configurations
-type TCPServerPoolConfigs struct {
+// TcpConnPoolConfigs represent configuration parameters for managing
+// a pool of TCP connections.
+// These configurations are https://github.com/knadh/koanf compatible.
+type TcpConnPoolConfigs struct {
 	MaxSize            int `koanf:"max-size"`
 	WaitForConnTimeout int `koanf:"wait-for-conn-timeout-ms"`
 	NoOpCycle          int `koanf:"noop-cycle-ms"`

--- a/pkg/config/logger.go
+++ b/pkg/config/logger.go
@@ -1,21 +1,17 @@
 package config
 
 import (
-	"os"
-
-	"go.elastic.co/ecszap"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // NewLogger Creates a new instance of Uber Zap
-func NewLogger() *zap.SugaredLogger {
-	encoderConfig := ecszap.NewDefaultEncoderConfig()
-	core := ecszap.NewCore(encoderConfig, os.Stdout, zap.DebugLevel)
-	logger := zap.New(core, zap.AddCaller())
-	return logger.Sugar()
+func NewLogger(zc zapcore.Core) *zap.Logger {
+	logger := zap.New(zc, zap.AddCaller())
+	return logger
 }
 
 // CloseLogger Flushes any pending logs
-func CloseLogger(logger *zap.SugaredLogger) {
+func CloseLogger(logger *zap.Logger) {
 	_ = logger.Sync()
 }

--- a/pkg/tcpserver/server.go
+++ b/pkg/tcpserver/server.go
@@ -4,6 +4,8 @@ import (
 	"context"
 )
 
+const ctxTraceID = 0
+
 type Server interface {
 	Start(ctx context.Context)
 	Close()


### PR DESCRIPTION
This commit refactors TCP server and its related components, specifically improving TCP server configurations, logging method, and adding a tracing ID constant for server context. The TCP connection pool configurations are now koanf-compatible, and the logger and handler have been modified to use `zap.Logger` instead of `zap.SugaredLogger`. It also includes necessary changes across examples and main application to reflect these changes.